### PR TITLE
fix: keep the right sentinel at the end of the content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emmgfx/scroll-hint",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Scroll edge indicators for React using IntersectionObserver",
   "keywords": [
     "react",

--- a/src/ScrollHint.tsx
+++ b/src/ScrollHint.tsx
@@ -86,7 +86,13 @@ export function ScrollHint({
             position: "relative",
             minHeight: "100%",
             minWidth: "100%",
-            ...(horizontal && { display: "inline-block", verticalAlign: "top" }),
+            // width: max-content is what keeps the right sentinel at the end of
+            // the content. Without it, inline-block shrink-to-fit caps this
+            // wrapper at the visible width whenever a block-level child
+            // overflows instead of widening (a grid, a table, a flex row), and
+            // the sentinel sits at the edge of the viewport: the right
+            // indicator would only appear after scrolling a full viewport.
+            ...(horizontal && { display: "inline-block", verticalAlign: "top", width: "max-content" }),
           }}
         >
           {vertical && (


### PR DESCRIPTION
## The bug

With `direction="horizontal"`, the right indicator only shows up after scrolling roughly half the range, instead of being on from the start.

The inner wrapper sizes itself with `display: inline-block` and no explicit width, so it shrink-to-fits to the available width. That works when the content is inline or sized to its own width, but a block-level child that is wider than the viewport (a CSS grid, a table, a flex row) overflows its parent instead of widening it. The wrapper stays at the visible width, and the right sentinel — absolutely positioned at `right: 0` inside it — sits at the edge of the viewport rather than at the end of the content. The observer sees it as visible, so the indicator stays off until the user scrolls a full viewport.

## The fix

`width: max-content` on the inner wrapper when `horizontal`. The existing `min-width: 100%` still covers content narrower than the viewport.

## Measurements

A 20-item, two-row carousel: 1137px visible, 3130px scrollable.

| | before | after |
|---|---|---|
| inner wrapper width | 1137 | 3130 |
| right sentinel at `scrollLeft: 0` | x=1136, inside the viewport | x=3129, outside |
| right indicator at start | off until ~57% of the range | on |

Indicator states after the fix — start: `left 0 / right 1`, middle: `1 / 1`, end: `1 / 0`.

## Note for consumers

Percentage-based widths inside the scrolled content need care: once the wrapper is `max-content`, a `%` resolves against an intrinsically-sized ancestor. Container query units (`cqw`) against the `ScrollHint` wrapper work well.

Version bumped to 0.2.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)