### PR TITLE
chore: 0.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emmgfx/scroll-hint",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Scroll edge indicators for React using IntersectionObserver",
   "keywords": [
     "react",


### PR DESCRIPTION
`0.2.3` was published with a `dist/` built before #8, so the released package does not contain the `width: max-content` fix — the installed bundle still reads `{ display: "inline-block", verticalAlign: "top" }`. npm does not allow republishing a version, so this bumps to `0.2.4`.

Publish checklist, since `dist/` is not in the repo and `files` only ships `dist`:

```
npm ci && npm run build
grep -c max-content dist/index.js   # must be 2
npm publish
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)