### PR TITLE
feat: expose the scroller and its edge state

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ import { ScrollHint } from "@emmgfx/scroll-hint";
 | `shadowSize` | `number` | `20` | Height/width of the shadow overlays in pixels |
 | `lineColor` | `string` | `undefined` | CSS color for a solid line at the edge. Omit to disable |
 | `lineSize` | `number` | `1` | Thickness of the solid line in pixels |
+| `scrollerRef` | `RefObject<HTMLDivElement \| null>` | `undefined` | Ref to the scrolling element, to drive it from outside. Must be a stable object ref: it is used as the internal ref, not copied into it |
+| `scrollerProps` | `HTMLAttributes<HTMLDivElement>` | `undefined` | Props for the scrolling element — `className` for scroll-snap, `tabIndex` and `aria-label` to make it keyboard reachable... `flex`, `minWidth`, `minHeight` and both `overflow` axes are set by the component and cannot be overridden |
+| `onEdgesChange` | `(edges: ScrollHintEdges) => void` | `undefined` | Called on mount and whenever an edge changes, with `{ top, bottom, left, right }`: `true` means there is more content past that edge. Same state that drives the indicators |
 
 All standard `div` props are forwarded to the outer wrapper element.
 
@@ -58,6 +61,34 @@ All standard `div` props are forwarded to the outer wrapper element.
 **Line + shadow combined:**
 ```jsx
 <ScrollHint lineColor="rgba(0,0,0,0.1)">
+  {/* content */}
+</ScrollHint>
+```
+
+**Your own arrows:** the indicators are decoration — they carry `pointer-events: none`. For clickable controls, put your own on top: `onEdgesChange` tells you when to show each one, and `scrollerRef` scrolls.
+
+```jsx
+const scroller = useRef(null);
+const [edges, setEdges] = useState({ left: false, right: false });
+
+const scrollBy = (sign) =>
+  scroller.current?.scrollBy({ left: (sign * scroller.current.clientWidth) / 2, behavior: "smooth" });
+
+<div style={{ position: "relative" }}>
+  <ScrollHint direction="horizontal" scrollerRef={scroller} onEdgesChange={setEdges}>
+    {/* content */}
+  </ScrollHint>
+  {edges.left && <button onClick={() => scrollBy(-1)}>←</button>}
+  {edges.right && <button onClick={() => scrollBy(1)}>→</button>}
+</div>
+```
+
+**Keyboard reachable and snapping:**
+```jsx
+<ScrollHint
+  direction="horizontal"
+  scrollerProps={{ tabIndex: 0, "aria-label": "Photos", className: "snap-x snap-mandatory" }}
+>
   {/* content */}
 </ScrollHint>
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emmgfx/scroll-hint",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "Scroll edge indicators for React using IntersectionObserver",
   "keywords": [
     "react",

--- a/src/ScrollHint.tsx
+++ b/src/ScrollHint.tsx
@@ -2,12 +2,22 @@ import { useEffect, useRef, useState } from "react";
 
 export type ScrollHintDirection = "vertical" | "horizontal" | "both";
 
+/** Whether there is more content past each edge — the same state that drives the indicators. */
+export type ScrollHintEdges = { top: boolean; bottom: boolean; left: boolean; right: boolean };
+
 export interface ScrollHintProps extends React.HTMLAttributes<HTMLDivElement> {
   direction?: ScrollHintDirection;
   shadowColor?: string;
   shadowSize?: number;
   lineColor?: string;
   lineSize?: number;
+  /** Ref to the scrolling element, to drive it from outside (scrollBy, scrollTo...). Pass a
+   * stable object ref: it is used as the internal ref, not copied into it. */
+  scrollerRef?: React.RefObject<HTMLDivElement | null>;
+  /** Props for the scrolling element: className for scroll-snap, tabIndex and aria-label to make it keyboard reachable... */
+  scrollerProps?: React.HTMLAttributes<HTMLDivElement>;
+  /** Called on mount and whenever an edge changes, to render your own controls. */
+  onEdgesChange?: (edges: ScrollHintEdges) => void;
 }
 
 export function ScrollHint({
@@ -16,11 +26,16 @@ export function ScrollHint({
   shadowSize = 20,
   lineColor,
   lineSize = 1,
+  scrollerRef,
+  scrollerProps,
+  onEdgesChange,
   children,
   style,
   ...props
 }: ScrollHintProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
+  // The caller's ref, when given, is the internal one: a single ref, no copying
+  const internalRef = useRef<HTMLDivElement>(null);
+  const containerRef = scrollerRef ?? internalRef;
   const topRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const leftRef = useRef<HTMLDivElement>(null);
@@ -58,7 +73,16 @@ export function ScrollHint({
     }
 
     return () => observer.disconnect();
-  }, [direction]);
+  }, [direction, containerRef]);
+
+  // Kept in a ref so an inline callback does not fire this on every render
+  const onEdgesChangeRef = useRef(onEdgesChange);
+  useEffect(() => {
+    onEdgesChangeRef.current = onEdgesChange;
+  });
+  useEffect(() => {
+    onEdgesChangeRef.current?.(shadows);
+  }, [shadows]);
 
   const overlay = (active: boolean, style: React.CSSProperties) => ({
     position: "absolute" as const,
@@ -72,8 +96,12 @@ export function ScrollHint({
   return (
     <div style={{ position: "relative", display: "flex", flexDirection: "column", overflow: "hidden", isolation: "isolate", ...style }} {...props}>
       <div
+        {...scrollerProps}
         ref={containerRef}
         style={{
+          // Last on purpose: these five are what makes the scroller scroll, so
+          // they win over anything scrollerProps brings
+          ...scrollerProps?.style,
           flex: 1,
           minHeight: 0,
           minWidth: 0,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { ScrollHint } from "./ScrollHint";
-export type { ScrollHintProps, ScrollHintDirection } from "./ScrollHint";
+export type { ScrollHintProps, ScrollHintDirection, ScrollHintEdges } from "./ScrollHint";


### PR DESCRIPTION
## Why

The indicators are decoration: they carry `pointer-events: none`. Anything clickable — arrows to scroll a carousel, for instance — has to be rendered on top by the consumer. Today that is not possible without duplicating the detection the component already does:

- the scrolling element has no `ref` and no way to receive props, so it cannot be scrolled from outside, made keyboard reachable, or given `scroll-snap`
- the edge state, which is exactly when an arrow should show or hide, never leaves the component

## What

Three props, no behaviour change for existing users:

| prop | purpose |
|---|---|
| `scrollerRef` | ref to the scrolling element |
| `scrollerProps` | props for it: `className`, `tabIndex`, `aria-label`... |
| `onEdgesChange` | `{ top, bottom, left, right }`, on mount and on every change |

Two design notes:

**One ref, not two.** When `scrollerRef` is given it is used *as* the internal ref (`scrollerRef ?? internalRef`) instead of merging into it, so nothing is copied and there is no callback ref recreated on every render. It has to be a stable object ref; documented.

**The component wins on layout.** `scrollerProps.style` is spread first and `flex`, `minWidth`, `minHeight`, `overflowX` and `overflowY` after it. Those five are what makes the scroller scroll — letting `overflow: hidden` through would break scrolling and leave the indicator stuck on. It also matches how `className` already behaves, since inline styles beat classes.

README documents the props and adds two examples: external arrows, and a keyboard-reachable snapping scroller.

Version bumped to 0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)