### PR TITLE
feat: transitionDuration for the indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ import { ScrollHint } from "@emmgfx/scroll-hint";
 | `shadowSize` | `number` | `20` | Height/width of the shadow overlays in pixels |
 | `lineColor` | `string` | `undefined` | CSS color for a solid line at the edge. Omit to disable |
 | `lineSize` | `number` | `1` | Thickness of the solid line in pixels |
+| `transitionDuration` | `string` | `"0.2s"` | How long the indicators take to fade in and out. Set to `"0s"` for no fade |
 | `scrollerRef` | `RefObject<HTMLDivElement \| null>` | `undefined` | Ref to the scrolling element, to drive it from outside. Must be a stable object ref: it is used as the internal ref, not copied into it |
 | `scrollerProps` | `HTMLAttributes<HTMLDivElement>` | `undefined` | Props for the scrolling element — `className` for scroll-snap, `tabIndex` and `aria-label` to make it keyboard reachable... `flex`, `minWidth`, `minHeight` and both `overflow` axes are set by the component and cannot be overridden |
 | `onEdgesChange` | `(edges: ScrollHintEdges) => void` | `undefined` | Called on mount and whenever an edge changes, with `{ top, bottom, left, right }`: `true` means there is more content past that edge. Same state that drives the indicators |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@emmgfx/scroll-hint",
-  "version": "0.2.2",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@emmgfx/scroll-hint",
-      "version": "0.2.2",
+      "version": "0.3.1",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emmgfx/scroll-hint",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Scroll edge indicators for React using IntersectionObserver",
   "keywords": [
     "react",

--- a/src/ScrollHint.tsx
+++ b/src/ScrollHint.tsx
@@ -11,6 +11,8 @@ export interface ScrollHintProps extends React.HTMLAttributes<HTMLDivElement> {
   shadowSize?: number;
   lineColor?: string;
   lineSize?: number;
+  /** How long the indicators take to fade in and out. Set to "0s" for no fade. */
+  transitionDuration?: string;
   /** Ref to the scrolling element, to drive it from outside (scrollBy, scrollTo...). Pass a
    * stable object ref: it is used as the internal ref, not copied into it. */
   scrollerRef?: React.RefObject<HTMLDivElement | null>;
@@ -26,6 +28,7 @@ export function ScrollHint({
   shadowSize = 20,
   lineColor,
   lineSize = 1,
+  transitionDuration = "0.2s",
   scrollerRef,
   scrollerProps,
   onEdgesChange,
@@ -89,7 +92,7 @@ export function ScrollHint({
     pointerEvents: "none" as const,
     zIndex: 1,
     opacity: active ? 1 : 0,
-    transition: "opacity 0.2s",
+    transition: `opacity ${transitionDuration}`,
     ...style,
   });
 


### PR DESCRIPTION
The indicators fade in and out over a hardcoded `0.2s`, written straight into the inline style of every overlay. A consumer who wants them to appear at once, or slower, can only get there by overriding an inline style with `!important` and a selector that reaches into the component's DOM.

`transitionDuration` takes any CSS duration and defaults to `"0.2s"`, so nothing changes for current users. `"0s"` removes the fade.

Version bumped to 0.3.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)